### PR TITLE
Resolve #2 Feature/introduce swagger documentation

### DIFF
--- a/app/Console/Commands/CheckProductStatus.php
+++ b/app/Console/Commands/CheckProductStatus.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Khufu\Product;
+use App\Models\Alexandros\Product;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Log;

--- a/app/Http/Controllers/Alexandros/ProductsController.php
+++ b/app/Http/Controllers/Alexandros/ProductsController.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Http\Controllers\Alexandros;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Carbon\Carbon;
+
+use App\Http\Requests\Alexandros\Product\CreateRequest;
+use App\Http\Resources\Alexandros\Product\ProductResource;
+use App\Models\Alexandros\Product;
+
+class ProductsController extends Controller
+{
+    public function create(CreateRequest $request){
+
+        $name = $request->name;
+        $description = $request->description;
+        $price = $request->price;
+        $start_at = Carbon::parse($request->start_date);
+        $end_at = Carbon::parse($request->end_date);
+        $customfields = $request->customfields;
+        $dataUrls = json_decode($request->images);
+
+        // Get the mime type and the data from the dataUrl
+        foreach ($dataUrls as $key => &$dataUrl) {
+
+            if (!isset($dataUrl) || empty($dataUrl)) {
+                continue;
+            }
+
+            $dataUrl = $this->saveImageAndReturnFileName($dataUrl);
+        }
+
+        // if today is before the start date or after the end date, switch status to false(currently unavailable)
+        $status = 1;
+        $today = Carbon::today();
+        if (($start_at && $start_at->lte($today)) || ($end_at && $today->lte($end_at))) {
+            $status = 0;
+        }
+
+        $newProduct = Product::create([
+            'name' => $name,
+            'description' => $description,
+            'price' => $price,
+            'status' => $status,
+            'start_at' => $start_at,
+            'end_at' => $end_at,
+            'customfields' => $customfields,
+            'images' => json_encode($dataUrls),
+        ]);
+
+        return $newProduct;
+    }
+
+    public function read(Request $request){
+        $product = Product::find($request->id);
+        if (!isset($product['images']) || empty($product['images'])) {
+            return $product;
+        }
+        $images = json_decode($product['images']);
+
+        // Get all images' dataUrl
+        foreach ($images as $imageKey => &$imageValue) {
+            if (!isset($imageValue) || empty($imageValue)) {
+                continue;
+            }
+
+            try {
+                $imageValue = Storage::disk('public')->url("/uploads/" . $imageValue);
+            } catch (Exception $e) {
+                return Log::error($e);
+            }
+        }
+
+        $product['images'] = json_encode($images);
+
+        return $product;
+    }
+
+    public function index() {
+        $products =  Product::all();
+
+        // Get only first image's dataUrl
+        foreach($products as $product) {
+            $images = json_decode($product['images']);
+            
+            if (!isset($images[0]) && empty($images[0])) {
+                $product['main_image'] = null;
+                continue;
+            }
+            
+            try {
+                $product['main_image'] = Storage::disk('public')->url("/uploads/" . $images[0]);
+            } catch (Exception $e) {
+                return Log::error($e);
+            }
+        }
+
+        return ProductResource::collection($products);
+    }
+
+    public function update(Request $request){
+        $id = $request->id;
+        $name = $request->name;
+        $description = $request->description;
+        $price = $request->price;
+        $start_at = Carbon::parse($request->start_date);
+        $end_at = Carbon::parse($request->end_date);
+        $customfields = $request->customfields;
+        $dataUrls = json_decode($request->images);
+
+        $product = Product::find($id);
+
+        // update images if needed
+        $images = json_decode($product->images, true);
+        $isImageUpdated = false;
+        if (isset($dataUrls) && !empty($dataUrls)) {
+            $images = array_filter($images, function($value) {
+                return $value !== "\0";
+            });
+            // check requested images
+            foreach ($dataUrls as $key => $dataUrl) {
+                // if image updated
+                if (isset($dataUrl) && !empty($dataUrl) && substr($dataUrl, 0, 4) != "http") {
+                    if (isset($images[$key]) && !empty($images[$key])) {
+                        $this->deleteImage($images[$key]);
+                    }
+                    $images[$key] = $this->saveImageAndReturnFileName($dataUrl);
+                    $isImageUpdated = true;
+                }
+            }
+            if($isImageUpdated) {
+                $product->images = $images;
+                $product->save();
+            }
+        }
+        
+        
+        $product->update([
+            'name' => $name,
+            'description' => $description,
+            'price' => $price,
+            'start_at' => $start_at,
+            'end_at' => $end_at,
+            'customfields' => $customfields,
+        ]);
+        
+        // if today is before the start date or after the end date, switch status to false(currently unavailable)
+        $today = Carbon::today();
+        if ($start_at || $end_at) {
+            $status = 1;
+            if ($start_at->lte($today) || $today->lte($end_at)) {
+                $status = 0;
+            }
+            $product->update([
+                'status' => $status,
+                'start_at' => $start_at,
+                'end_at' => $end_at,
+            ]);
+        }
+        return $product;
+    }
+
+    public function delete(Request $request){
+        $product = Product::find($request->id);
+
+        // delete preexisting images
+        if (isset($product['images']) && !empty($product['images'])) {
+            $images = json_decode($product['images']);
+            
+            foreach ($images as $imageKey => &$filename) {
+                if (!isset($filename) || empty($filename)) {
+                    continue;
+                }
+                $this->deleteImage($filename);
+            }
+        }
+
+        return Product::find($request->id)->delete();
+    }
+
+
+    private function saveImageAndReturnFileName($dataUrl){
+        // Split the data URL into its parts
+        $parts = explode(',', $dataUrl);
+    
+        // Extract the mime type and the base64 encoded data
+        $mimeType = explode(';', $parts[0])[0];
+        $base64Data = $parts[1];
+    
+        // Decode the base64 encoded data
+        $data = base64_decode($base64Data);
+    
+        // Save the file
+        $filename = uniqid() . '.' . explode('/', $mimeType)[1];
+        Storage::disk('public')->put('/uploads/' . $filename, $data);
+    
+        // Store the filename back into the $dataUrls array
+        $dataUrl = substr($filename, 0);
+
+        return $dataUrl;
+    }
+
+    private function deleteImage($filename) {
+        Storage::disk('public')->delete('/uploads/' . $filename);
+    }
+
+}

--- a/app/Http/Controllers/Alexandros/ProductsController.php
+++ b/app/Http/Controllers/Alexandros/ProductsController.php
@@ -81,6 +81,25 @@ class ProductsController extends Controller
         return $product;
     }
 
+     /**
+     * @OA\Get(
+     *     path="/api/products",
+     *     summary="Updates a user",
+     *     @OA\Parameter(
+     *         description="Parameter with mutliple examples",
+     *         in="path",
+     *         name="id",
+     *         required=true,
+     *         @OA\Schema(type="string"),
+     *         @OA\Examples(example="int", value="1", summary="An int value."),
+     *         @OA\Examples(example="uuid", value="0006faf6-7a61-426c-9034-579f2cfcfa83", summary="An UUID value."),
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="OK"
+     *     )
+     * )
+     */
     public function index() {
         $products =  Product::all();
 

--- a/app/Http/Controllers/Alexandros/SchedulesController.php
+++ b/app/Http/Controllers/Alexandros/SchedulesController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Controllers\Alexandros;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use GuzzleHttp\Client;
+
+use App\Http\Requests\Alexandros\Schedule\CreateRequest;
+use App\Http\Requests\Alexandros\Schedule\SearchRequest;
+use App\Http\Resources\Alexandros\Schedule\ProductResource;
+use App\Models\Alexandros\Product;
+use App\Models\Alexandros\Schedule;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+
+
+use Carbon\Carbon;
+
+class SchedulesController extends Controller
+{
+    public function search(SearchRequest $request) {
+        return ProductResource::collection($this->getAvailableProducts($request->start_at, $request->end_at));
+    }
+    
+    private function getAvailableProducts($start_at, $end_at, $returnType = null) {
+        // Format dateTimes
+        $formattedStartAt = Carbon::parse($start_at);
+        $formattedEndAt = Carbon::parse($end_at);
+
+
+        // get booked product_ids
+        $bookedProducts = Schedule::where(function ($query) use ($formattedStartAt, $formattedEndAt) {
+                                $query->whereBetween('start_at', [$formattedStartAt, $formattedEndAt])
+                                    ->orWhereBetween('end_at', [$formattedStartAt, $formattedEndAt]);
+                            })
+                            ->orWhere(function ($query) use ($formattedStartAt, $formattedEndAt) {
+                                $query->where('start_at', '<', $formattedStartAt)
+                                    ->where('end_at', '>', $formattedEndAt);
+                            })
+                            ->pluck('product_id')->toArray();
+        
+        // get available products
+        $availableProductsQuery = Product::where(function ($query) use ($bookedProducts) {
+            $query->whereNotIn('id', $bookedProducts)
+                ->where('status', 1);
+        })
+        ->orWhere(function ($query) use ($formattedStartAt, $formattedEndAt, $bookedProducts){
+            $query->where('status', 0)
+                ->whereNotIn('id', $bookedProducts)
+                ->where('start_at', '<', $formattedStartAt)
+                ->where(function ($query) use ($formattedEndAt) {
+                    $query->where('end_at', '>', $formattedEndAt)
+                        ->orWhereNull('end_at');
+                });
+        });
+
+        if ($returnType === 'id') {
+            return $availableProductsQuery->pluck('id')->toArray();
+        }
+        return $availableProductsQuery->get();
+    }
+    
+    public function create(CreateRequest $request) {
+        // user info
+        $customerName = $request->name;
+        $customerEmail = $request->email;
+        $customerTel = $request->tel;
+
+        // schedul info
+        $productId = $request->product_id;
+        $start_at = $request->start_at;
+        $end_at = $request->end_at;
+        $total_fee = $request->total_fee;
+        $customfields = json_decode($request->customfields);
+
+        // check if the product is available during the selected hours
+        $availableProductIds = $this->getAvailableProducts($start_at, $end_at, 'id');
+        if (!in_array($productId, $availableProductIds)) {
+            return response()->json(['message' => 'The productId: {' . $productId . '} is not available.'], 400); 
+        }
+
+        // save customer information to users table.
+        $customerInfo = User::create([
+            'name' => $customerName,
+            'email' => $customerEmail,
+            'customfields' => json_encode([
+                'tel' => $customerTel,
+                'licenseNumber' => $customfields->licenseNumber,
+                'dob' => $customfields->dob,
+            ])
+        ]);
+
+        // save schedule information to schedules table.
+        $scheduleInfo = Schedule::create([
+            'product_id' => $productId,
+            'user_id' => $customerInfo->id,
+            'start_at' => $start_at,
+            'end_at' => $end_at,
+            'total_fee' => $total_fee,
+            'customfields' => json_encode([
+                "airportPickup" => $customfields->airportPickup,
+                "airportDropoff" => $customfields->airportDropoff,
+                "akamineStaDelivery" => ($customfields->akamineStaDelivery) ? $customfields->akamineStaDelivery : null ,
+                "useOfChiledSheet" => ($customfields->useOfChiledSheet) ? $customfields->useOfChiledSheet : null
+            ])
+        ]);
+
+        $productInfo = Product::find($scheduleInfo->product_id);
+
+        $optionTextAkamineStaDelivery = $customfields->akamineStaDelivery ? "あり" : "なし";
+        $optionTextUseOfChildSheet = $customfields->useOfChiledSheet == 1 ? "ベビーシートあり" : ($customfields->useOfChiledSheet == 2 ? "ジュニアシートあり" : "なし");
+
+        $this->sendAdminSlackNotice([
+            "type" => "mrkdwn",
+            "text" => "<!channel> 予約が入りました！
+                \n*予約内容*:\n>予約ID：$scheduleInfo->id\n>時間：$scheduleInfo->start_at ~ $scheduleInfo->end_at\n>空港お出迎え時刻：$customfields->airportPickup\n>空港お見送り時刻：$customfields->airportDropoff
+                \n*お客様情報*:\n>お名前：$customerInfo->name\n>メールアドレス：$customerInfo->email\n>電話番号：$customerTel\n>免許証番号：$customfields->licenseNumber\n>生年月日：$customfields->dob
+                \n*車両情報*:\n>車両ID：$productInfo->id\n>車名：$productInfo->name
+                \n*オプション情報*:\n>赤嶺駅貸出： $optionTextAkamineStaDelivery\n>チャイルドシート：$optionTextUseOfChildSheet
+                \nfrom： ".env('APP_URL')
+        ]);
+
+        return $request;
+    }
+
+    private function sendAdminSlackNotice($messageContent)
+    {
+        $client = new Client();
+
+        $response = $client->post(env('SLACK_WEBHOOK_URL'), [
+            'json' => $messageContent,
+        ]);
+
+        if ($response->getStatusCode() == 200) {
+            return [
+                'message' => 'Message sent successfully',
+                'status' => 200
+            ];
+        } else {
+            Log::error(json_encode($response));
+            return [
+                'message' => 'Failed to send message',
+                'status' => 500
+            ];
+        }
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -9,7 +9,7 @@ use Illuminate\Routing\Controller as BaseController;
  /**
  * @OA\Info(
  *     version="1.0",
- *     title="Example for response examples value"
+ *     title="Product Management Tool BackEnd API Document"
  * )
  */
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -6,6 +6,13 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller as BaseController;
 
+ /**
+ * @OA\Info(
+ *     version="1.0",
+ *     title="Example for response examples value"
+ * )
+ */
+
 class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;

--- a/app/Http/Requests/Alexandros/Product/CreateRequest.php
+++ b/app/Http/Requests/Alexandros/Product/CreateRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests\Alexandros\Product;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class CreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    // public function authorize()
+    // {
+    //     return true;
+    // }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255'
+            ],
+            'description' => [
+                'max:500'
+            ],
+            'price' => [
+                'required',
+                'numeric'
+            ],
+            'customfields' => [
+                'json',
+            ],
+        ];
+    }
+    
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json($validator->errors(), 422));
+    }
+}

--- a/app/Http/Requests/Alexandros/Schedule/CreateRequest.php
+++ b/app/Http/Requests/Alexandros/Schedule/CreateRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Requests\Alexandros\Schedule;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class CreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    // public function authorize()
+    // {
+    //     return true;
+    // }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'product_id' => [
+                'required',
+                'max:255'
+            ],
+            'name' => [
+                'string',
+                'max:255'
+            ],
+            'email' => [
+                'required',
+                'email',
+                'max:255'
+            ],
+            'tel' => [
+                'regex:/[0-9]{7,13}/'
+            ],
+            'start_at' => [
+                'required',
+                'date_format:Y-m-d H:i'
+            ],
+            'end_at' => [
+                'required',
+                'date_format:Y-m-d H:i'
+            ],
+            'total_fee' => [
+                'required',
+                'numeric'
+            ],
+            'customfields' => [
+                'json',
+            ],
+        ];
+    }
+    
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json($validator->errors(), 422));
+    }
+}

--- a/app/Http/Requests/Alexandros/Schedule/SearchRequest.php
+++ b/app/Http/Requests/Alexandros/Schedule/SearchRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Alexandros\Schedule;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class SearchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    // public function authorize()
+    // {
+    //     return true;
+    // }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            
+            'start_at' => [
+                'required',
+                'date_format:Y-m-d H:i'
+            ],
+            'end_at' => [
+                'required',
+                'date_format:Y-m-d H:i'
+            ],
+        ];
+    }
+    
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json($validator->errors(), 422));
+    }
+}

--- a/app/Http/Resources/Alexandros/Product/ProductResource.php
+++ b/app/Http/Resources/Alexandros/Product/ProductResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources\Alexandros\Product;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class ProductResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+
+        return [
+            "id" => $this->id,
+            "name" => $this->name,
+            "main_image" => $this->main_image,
+            "startDate" => $this->start_at,
+            "endDate" => $this->end_at,
+            "status" => $this->status,
+            "customfields" => $this->customfields,
+        ];
+    }
+}

--- a/app/Http/Resources/Alexandros/Schedule/ProductResource.php
+++ b/app/Http/Resources/Alexandros/Schedule/ProductResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Alexandros\Schedule;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class ProductResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $images = json_decode($this->images);
+        foreach($images as $key => $image) {
+            if (isset($image) && !empty($image)) {
+                $images[$key] = Storage::disk('public')->url("/uploads/" . $image);
+            }
+        }
+
+        return [
+            "id" => $this->id,
+            "title" => $this->name,
+            "price" => $this->price,
+            "customfields" => $this->customfields,
+            "images" => $images
+        ];
+    }
+}

--- a/app/Models/Alexandros/AdminUser.php
+++ b/app/Models/Alexandros/AdminUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Alexandros;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AdminUser extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Alexandros/Customfield.php
+++ b/app/Models/Alexandros/Customfield.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Alexandros;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Customfield extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Alexandros/CustomfieldData.php
+++ b/app/Models/Alexandros/CustomfieldData.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Alexandros;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomfieldData extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Alexandros/Product.php
+++ b/app/Models/Alexandros/Product.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Alexandros;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+    protected $table = 'products';
+
+    protected $fillable = [
+        'name',
+        'description',
+        'images',
+        'status',
+        'price',
+        'start_at',
+        'end_at',
+        'customfields'
+    ];
+}

--- a/app/Models/Alexandros/Schedule.php
+++ b/app/Models/Alexandros/Schedule.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Alexandros;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Schedule extends Model
+{
+    use HasFactory;
+    protected $table = 'schedules';
+
+    protected $fillable = [
+        'product_id',
+        'user_id',
+        'start_at',
+        'end_at',
+        'total_fee',
+        'customfields'
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "darkaonline/l5-swagger": "^8.5",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb2a68a524a0cb94c9ba8c7802345ff9",
+    "content-hash": "0c23faa25ad321a3476bac17cecbaad7",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -211,6 +211,86 @@
             "time": "2023-01-15T23:15:59+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "8.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "2558ac430be2f825436267e6774bd407eab95372"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/2558ac430be2f825436267e6774bd407eab95372",
+                "reference": "2558ac430be2f825436267e6774bd407eab95372",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^10.0 || ^9.0 || >=8.40.0 || ^7.0",
+                "php": "^7.2 || ^8.0",
+                "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^3.2.0 || ^4.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^10.0 || ^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ],
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/8.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-12T09:53:16+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.2",
             "source": {
@@ -284,6 +364,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
             },
             "time": "2022-10-27T11:44:00+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.8.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6",
+                "vimeo/psalm": "^4.10"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
+            },
+            "time": "2023-02-02T22:02:53+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2672,6 +2828,55 @@
             "time": "2023-11-12T21:59:55+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3387,6 +3592,67 @@
                 }
             ],
             "time": "2023-11-08T05:53:05+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "0eddc1563b387fb15bf3bb56b7916128d728554b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/0eddc1563b387fb15bf3bb56b7916128d728554b",
+                "reference": "0eddc1563b387fb15bf3bb56b7916128d728554b",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.11.2"
+            },
+            "time": "2024-01-29T08:56:01+00:00"
         },
         {
             "name": "symfony/console",
@@ -5640,6 +5906,78 @@
             "time": "2023-11-08T10:42:36+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v6.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "3493af8a8dad7fa91c77fa473ba23ecd95334a92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3493af8a8dad7fa91c77fa473ba23ecd95334a92",
+                "reference": "3493af8a8dad7fa91c77fa473ba23ecd95334a92",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.3.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-06T10:58:05+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.6",
             "source": {
@@ -5907,6 +6245,87 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "4.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "598958d8a83cfbd44ba36388b2f9ed69e8b86ed4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/598958d8a83cfbd44ba36388b2f9ed69e8b86ed4",
+                "reference": "598958d8a83cfbd44ba36388b2f9ed69e8b86ed4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^1.7 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
+                "phpstan/phpstan": "^1.6",
+                "phpunit/phpunit": ">=8",
+                "vimeo/psalm": "^4.23"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.7 || ^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/4.8.3"
+            },
+            "time": "2024-01-07T22:33:09+00:00"
         }
     ],
     "packages-dev": [
@@ -8225,78 +8644,6 @@
                 }
             ],
             "time": "2023-10-09T12:55:26+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v6.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "3493af8a8dad7fa91c77fa473ba23ecd95334a92"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3493af8a8dad7fa91c77fa473ba23ecd95334a92",
-                "reference": "3493af8a8dad7fa91c77fa473ba23ecd95334a92",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<5.4"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.3.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-11-06T10:58:05+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,300 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                 * File name of the generated json documentation file
+                */
+                // 'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'yaml'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                */
+                'annotations' => [
+                    base_path('app'),
+                ],
+
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+            */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+            */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+            */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+            */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+            */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+            */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+            */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Edit to set path where swagger ui assets should be stored
+            */
+            'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+            */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/schema-query-parameter-processor
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+            */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+        */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', true),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+        */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', true),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+        */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+        */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+        */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+        */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+        */
+        'ui' => [
+            'display' => [
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                    * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                    */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -5,7 +5,7 @@ return [
     'documentations' => [
         'default' => [
             'api' => [
-                'title' => 'L5 Swagger UI',
+                'title' => 'Product Mangement API',
             ],
 
             'routes' => [
@@ -210,7 +210,7 @@ return [
                         'write'
                     ],
 
-                    'passport' => []
+                    'passport' 。=> []
                     */
                 ],
             ],

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{config('l5-swagger.documentations.'.$documentation.'.api.title')}}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+</head>
+
+<body>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            url: "{!! $urlToDocs !!}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,8 +3,8 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ApiTestController;
-use App\Http\Controllers\Khufu\ProductsController;
-use App\Http\Controllers\Khufu\SchedulesController;
+use App\Http\Controllers\Alexandros\ProductsController;
+use App\Http\Controllers\Alexandros\SchedulesController;
 
 /*
 |--------------------------------------------------------------------------
@@ -23,14 +23,14 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::get('/test', [ApiTestController::class, 'test']);
 
-// Khufu ProductsTable
+// Alexandros ProductsTable
 Route::post('/products/create', [ProductsController::class, 'create']);
 Route::get('/products', [ProductsController::class, 'index']);
 Route::get('/products/{id}', [ProductsController::class, 'read']);
 Route::patch('/products/{id}', [ProductsController::class, 'update']);
 Route::delete('/products/{id}', [ProductsController::class, 'delete']);
 
-// Khufu ScheduleTable
+// Alexandros ScheduleTable
 Route::get('/schedule/search', [SchedulesController::class, 'search']);
 Route::post('/schedule/create', [SchedulesController::class, 'create']);
 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1,0 +1,46 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Example for response examples value",
+        "version": "1.0"
+    },
+    "servers": [
+        {
+            "url": "http://127.0.0.1:8000"
+        }
+    ],
+    "paths": {
+        "/api/products": {
+            "get": {
+                "summary": "Updates a user",
+                "operationId": "d12de6803e6268d496f390cc18681598",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Parameter with mutliple examples",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "examples": {
+                            "int": {
+                                "summary": "An int value.",
+                                "value": "1"
+                            },
+                            "uuid": {
+                                "summary": "An UUID value.",
+                                "value": "0006faf6-7a61-426c-9034-579f2cfcfa83"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1,7 +1,7 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "title": "Example for response examples value",
+        "title": "Product Management Tool BackEnd API Document",
         "version": "1.0"
     },
     "servers": [

--- a/storage/api-docs/api-docs.yaml
+++ b/storage/api-docs/api-docs.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: 'Example for response examples value'
+  title: 'Product Management Tool BackEnd API Document'
   version: '1.0'
 servers:
   -

--- a/storage/api-docs/api-docs.yaml
+++ b/storage/api-docs/api-docs.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  title: 'Example for response examples value'
+  version: '1.0'
+servers:
+  -
+    url: 'http://127.0.0.1:8000'
+paths:
+  /api/products:
+    get:
+      summary: 'Updates a user'
+      operationId: d12de6803e6268d496f390cc18681598
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Parameter with mutliple examples'
+          required: true
+          schema:
+            type: string
+          examples:
+            int:
+              summary: 'An int value.'
+              value: '1'
+            uuid:
+              summary: 'An UUID value.'
+              value: 0006faf6-7a61-426c-9034-579f2cfcfa83
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
### summary
Introduce swagger API documentation

### steps followed
1. update project name(Khufu -> Alexandros) in each module: 
   - Console
   - Route
   - Model
   - Controller
   - Request
   - Resource
3. install swagger board generator: 
```
composer require darkaonline/l5-swagger
```
4. load the swagger generator by initializing l5-swagger config file
```
php artisan vendor:publish --provider "L5Swagger\L5SwaggerServiceProvider"
```
5. customize l5-swagger generator configuration
   - api doc title
      ```
      'api' => [
                      'title' => 'Product Mangement API',
                  ],
      ```
   - enable load of yaml doc for docment page display: `'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'yaml'),`
   - enable yaml doc generation beside json: `'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', true),`
   - enable auto re-generation of documentation: `'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', true),`
   - update base path of apis(configure in the .env file): `L5_SWAGGER_BASE_PATH=http://127.0.0.1:8000`

6. Add example endpoint explanations to few function in controllers
   - `app/Http/Controllers/Controller.php`: add document title
   - `app/Http/Controllers/Alexandros/ProductsController.php`: add GET:`/api/products"` endpoint explanation as an example for now
7. Generate swagger document:
```
php artisan l5-swagger:generate
```